### PR TITLE
Fix main.go:77: undefined: importer.NewImporter

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"honnef.co/go/importer"
+	importer "github.com/dominikh/go-importer"
 
 	"code.google.com/p/go.tools/go/types"
 	"github.com/kisielk/gotool"
@@ -74,7 +74,7 @@ type Context struct {
 }
 
 func NewContext() *Context {
-	importer := importer.NewImporter()
+	importer := importer.New()
 	ctx := &Context{
 		allImports: importer.Imports,
 		context: types.Config{


### PR DESCRIPTION
I noticed the build was failing due to changes in the `importer` package.

> ...\github.com\Intermernet\implements\main.go:77: undefined: importer.NewImporter

This fixes the build but it may be worth updating `honnef.co/go/importer` from `github.com/dominikh/go-importer` to avoid the first code change.
